### PR TITLE
Fea fixget active file

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -132,7 +132,7 @@ export default class imageAutoUploadPlugin extends Plugin {
   async downloadAllImageFiles() {
     const fileArray = this.helper.getAllFiles();
     const folderPathAbs = this.getAttachmentFolderPath();
-    if (!folderPathAbs) {
+    if (folderPathAbs==null||!folderPathAbs) {
       new Notice(
       `Get attachment folder path faild.`
       );
@@ -202,7 +202,7 @@ export default class imageAutoUploadPlugin extends Plugin {
     const activeFile = this.app.vault.getAbstractFileByPath(
       this.app.workspace.getActiveFile()?.path
     );
-    if (!activeFile) {
+    if (activeFile==null||!activeFile) {
       return null;
     }
     const parentPath = activeFile.parent.path;

--- a/src/main.ts
+++ b/src/main.ts
@@ -132,6 +132,12 @@ export default class imageAutoUploadPlugin extends Plugin {
   async downloadAllImageFiles() {
     const fileArray = this.helper.getAllFiles();
     const folderPathAbs = this.getAttachmentFolderPath();
+    if (!folderPathAbs) {
+      new Notice(
+      `Get attachment folder path faild.`
+      );
+      return ;
+    }
     let absfolder = this.app.vault.getAbstractFileByPath(folderPathAbs);
     if (!absfolder) {
       this.app.vault.createFolder(folderPathAbs);
@@ -194,8 +200,11 @@ export default class imageAutoUploadPlugin extends Plugin {
       assetFolder = "/"
     }
     const activeFile = this.app.vault.getAbstractFileByPath(
-      this.app.workspace.getActiveFile().path
+      this.app.workspace.getActiveFile()?.path
     );
+    if (!activeFile) {
+      return null;
+    }
     const parentPath = activeFile.parent.path;
     // 当前文件夹下的子文件夹
     if (assetFolder.startsWith("./")) {


### PR DESCRIPTION
[getActiveFile](https://github.com/NekoTarou/lskypro-auto-upload/blob/2cc6b2ba59bd4e71bcc80946421eb9d93918ee0a/src/main.ts#L197) this function can return null. Make sure to handle that case.
see https://github.com/obsidianmd/obsidian-releases/pull/1962
---
If the current active file does not exist, the shortcut key is not available。